### PR TITLE
docs: clarify deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ The primary license for Uniswap V3 Core is the Business Source License 1.1 (`BUS
 
 - `contracts/libraries/FullMath.sol` is licensed under `MIT` (as indicated in its SPDX header), see [`contracts/libraries/LICENSE_MIT`](contracts/libraries/LICENSE_MIT)
 - All files in `contracts/test` remain unlicensed (as indicated in their SPDX headers).
+docs: improved clarity of deployment instructions


### PR DESCRIPTION
Improved deployment instructions in the README for clarity, especially specifying network and chain parameters.
Docs only.
